### PR TITLE
build: changes src of pdfXBlock & bumps to v0.5.1

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -6,7 +6,7 @@
 -e git+https://github.com/eol-uchile/eol_gradeforum_xblock@1b5160b01a081aa68b42f9aed87845fa88b2b8a0#egg=eolgradediscussion
 -e git+https://github.com/eol-uchile/eol_list_grade@0d7688919bad8b229bff2948f31fedd76f1029d2#egg=eollistgrade-xblock
 -e git+https://github.com/eol-uchile/edx-ora2.git@e873498bd2671b830f19a2441ec1608b7d4bbbc4#egg=ora2
--e git+https://github.com/open-uchile/pdfXBlock@471addf3b6f52d75f21ea3851bc081f8723b6e58#egg=pdf-xblock
+-e git+https://github.com/eol-uchile/pdfXBlock@v0.5.0#egg=pdf-xblock
 -e git+https://github.com/eol-uchile/edx_xblock_scorm@c23184c0e22a7847f0b0c917bbe431c2973770fb#egg=scormxblock-xblock
 -e git+https://github.com/eol-uchile/edx-sga@12948a546025eddf570eee59820b0356d42f6620#egg=edx-sga
 -e git+https://github.com/eol-uchile/ubcpi@ae4bac403c89fd6c6525cedb7171a66e3aefca4c#egg=ubcpi-xblock

--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -6,7 +6,7 @@
 -e git+https://github.com/eol-uchile/eol_gradeforum_xblock@1b5160b01a081aa68b42f9aed87845fa88b2b8a0#egg=eolgradediscussion
 -e git+https://github.com/eol-uchile/eol_list_grade@0d7688919bad8b229bff2948f31fedd76f1029d2#egg=eollistgrade-xblock
 -e git+https://github.com/eol-uchile/edx-ora2.git@e873498bd2671b830f19a2441ec1608b7d4bbbc4#egg=ora2
--e git+https://github.com/eol-uchile/pdfXBlock@v0.5.0#egg=pdf-xblock
+-e git+https://github.com/eol-uchile/pdfXBlock@v0.5.1#egg=pdf-xblock
 -e git+https://github.com/eol-uchile/edx_xblock_scorm@c23184c0e22a7847f0b0c917bbe431c2973770fb#egg=scormxblock-xblock
 -e git+https://github.com/eol-uchile/edx-sga@12948a546025eddf570eee59820b0356d42f6620#egg=edx-sga
 -e git+https://github.com/eol-uchile/ubcpi@ae4bac403c89fd6c6525cedb7171a66e3aefca4c#egg=ubcpi-xblock


### PR DESCRIPTION
El cambio de repo sólo se traduce en cambios en el código con respecto al agregado de las últimas funcionalidades que se necesitan y ya están en producción en edx-eol, staging y ou-staging.

Este cambio es parte de las tareas para eliminar el fork del xblock para openuchile, que es innecesario.