### PR TITLE
ci(diagram): fixes branch name to generate diagram

### DIFF
--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
   push:
     branches:
-      - 'main'
+      - 'openuchile-release/**'
     paths:
       - 'Dockerfile'
       - 'requirements/**.txt'


### PR DESCRIPTION
Se actualiza el nombre de la rama por defecto que se mira al momento de hacer un push para que modifique el diagrama