### PR TITLE
build: rm eol-zoom-xblock

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -10,4 +10,3 @@
 -e git+https://github.com/eol-uchile/edx_xblock_scorm@c23184c0e22a7847f0b0c917bbe431c2973770fb#egg=scormxblock-xblock
 -e git+https://github.com/eol-uchile/edx-sga@12948a546025eddf570eee59820b0356d42f6620#egg=edx-sga
 -e git+https://github.com/eol-uchile/ubcpi@ae4bac403c89fd6c6525cedb7171a66e3aefca4c#egg=ubcpi-xblock
--e git+https://github.com/eol-uchile/eol-zoom-xblock@52cfe736d9ba951345a9d41fc587ec8fdbdb3b9b#egg=eolzoom-xblock


### PR DESCRIPTION
Se saca eol-zoom-xblock del edx-openuchile porque no tiene asignado marketplace, no se usa, y en esta versión genera problemas de build de la imagen.