### PR TITLE
chore: remove unused api portal_api and apis.txt empty file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ FROM ghcr.io/eol-uchile/edx-platform:ou-koa-20250925190037 AS base
 COPY ./requirements/ /openedx/requirements
 RUN pip install --src ../venv/src -r /openedx/requirements/python_packages.txt
 RUN pip install --src ../venv/src -r /openedx/requirements/apps.txt
-RUN pip install --src ../venv/src -r /openedx/requirements/apis.txt
 RUN pip install --src ../venv/src -r /openedx/requirements/reports.txt
 RUN pip install --src ../venv/src -r /openedx/requirements/xblocks.txt
 RUN pip install --src ../venv/src -r /openedx/requirements/tabs_plugins.txt

--- a/requirements/apis.txt
+++ b/requirements/apis.txt
@@ -1,1 +1,0 @@
--e git+https://github.com/eol-uchile/portal_api@0.3#egg=portal_api


### PR DESCRIPTION
Se elimina portal_api, la cual ya no esta siendo refenciada ni usada por el tema
Ya se realizo la prueba en staging sin malos efectos y se reviso nuevamente el tema en busca de referencias a portal api y  no se encontro ninguna