### PR TITLE
build: update tag from eol_forum_notification to 1.0.4

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -2,7 +2,7 @@
 -e git+https://github.com/eol-uchile/corfo_generate_code@a6b171148ba7278c05c664f0eb41f52743634bd2#egg=corfogeneratecode
 -e git+https://github.com/eol-uchile/eol-course-program-xblock@0.1.1#egg=eolcourseprogram-xblock
 -e git+https://github.com/eol-uchile/eol_xblock_discussion@1.1.1#egg=eoldiscussion-xblock
--e git+https://github.com/eol-uchile/eol_forum_notifications@1.0.3#egg=eol_forum_notifications
+-e git+https://github.com/eol-uchile/eol_forum_notifications@1.0.4#egg=eol_forum_notifications
 -e git+https://github.com/eol-uchile/eol_gradeforum_xblock@1.0.0#egg=eolgradediscussion
 -e git+https://github.com/eol-uchile/eol_list_grade@1.0.0#egg=eollistgrade-xblock
 -e git+https://github.com/eol-uchile/edx-ora2.git@e873498bd2671b830f19a2441ec1608b7d4bbbc4#egg=ora2


### PR DESCRIPTION
Se actualiza el tag de eol_forum_notifications 1.0.4 
Se modifica el como se llama a la notificación del correo de emergencia dejandolo variable