### PR TITLE
build: add eol-certificates in 0.1.0 & update open-theme to 2.0.1

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -1,4 +1,5 @@
 -e git+https://github.com/eol-uchile/course_classification@1.2.1#egg=course_classification
+-e git+https://github.com/eol-uchile/eol-certificates@0.1.0#egg=eol_certificates
 -e git+https://github.com/eol-uchile/eol_contact_form@0.5.3#egg=eol_contact_form
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0#egg=eol_duplicate_xblock
 -e git+https://github.com/eol-uchile/eol_sso_login@0.1.1#egg=eol_sso_login


### PR DESCRIPTION
Se agrega la app eol-certificates en su version 0.1.0: que permite modularizar la revisión de la validación de certificados, por lo tanto permite

Se actualiza openuchile-theme tag a 2.0.1: 
Se actualizo el tema de open con lo siguiente:

Se eliminó una clase CSS no utilizada del elemento open-carousel-courses.
Se removió el CSS del contact_form que ya no estaba en uso.
Los enlaces a RRSS y los links en pestañas del index ahora se abren en una nueva pestaña.
Se actualizó el navbar tanto para usuarios autenticados como no autenticados.
Se mejoró el estilo del FAQ y se actualizaron las preguntas y respuestas.
Se mejoró el estilo del validador de certificados.
Se agregó el logo de Open edX al footer.
Se añadió un enlace “Show more” que redirige al explorador de cursos y muestra estado activo.
En la vista course about:

- Se incorporaron los campos advertised_start y extra data info.
- Se agregó un nuevo botón de re-run.
- Se realizaron mejoras de estilo. 

Se elimina el template de validate certificates y se estiliza con css la que viene original desde eol-certificates
Se actualizan las traducciones para reflejar cambios de eliminación de templates