### PR TITLE
build: update eol_xblock_discussion tag to 1.3.1

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -4,7 +4,7 @@
 -e git+https://github.com/eol-uchile/eol_forum_notifications@1.0.4#egg=eol_forum_notifications
 -e git+https://github.com/eol-uchile/eol_gradeforum_xblock@1.0.0#egg=eolgradediscussion
 -e git+https://github.com/eol-uchile/eol_list_grade@1.0.0#egg=eollistgrade-xblock
--e git+https://github.com/eol-uchile/eol_xblock_discussion@1.3.0#egg=eoldiscussion-xblock
+-e git+https://github.com/eol-uchile/eol_xblock_discussion@1.3.1#egg=eoldiscussion-xblock
 -e git+https://github.com/eol-uchile/eol-container-xblock.git@v1.1.0#egg=eolcontainer-xblock
 -e git+https://github.com/eol-uchile/eol-course-program-xblock@0.2.0#egg=eolcourseprogram-xblock
 -e git+https://github.com/eol-uchile/eol-persistent-tab-xblock@1.0.0#egg=eolpersistenttab-xblock


### PR DESCRIPTION
Se actualiza la rama de eol_xblock_discussion a 1.3.1 para corregir error de css al momento de agregar una nueva publicación